### PR TITLE
Release docker image for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u kwhadocker -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: kwhadocker/concourse-bitbucket-build-status-resource:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.10
 MAINTAINER Ecometrica <>
 
 ENV LANG C


### PR DESCRIPTION
Hi

Package Owner: Abhishek Nishant

PR change Details:

Patch Details: Following file has been created and modified :

Created **.github/workflows/ci.yml** file to build and push the image for both amd64 and arm64 platforms.
Replace base image from **alpine:3.4** to **alpine:3.10** to build image for arm64. 


PR Description: Here is my commit message :
Release docker image for arm64.

PR Description:

The following file has been created and modified :
Created **.github/workflows/ci.yml** file to build and push the image for both amd64 and arm64 platforms.
Replace base image from **alpine:3.4** to **alpine:3.10** to build image for arm64. 


Signed-off-by: odidev odidev@puresoftware.com
Reviewer: Pruthvi Teja Reddy
Thanks
Abhishek Nishant